### PR TITLE
Don't recompress if compressed data matches

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,1 @@
+from .pelican_precompress import *


### PR DESCRIPTION
When `PRECOMPRESS_OVERWRITE` is enabled, check whether the existing compressed file decompresses to match the source file before re-compressing. Gives substantial speedup, as decompression is fast.