### PR TITLE
Various speed optimizations

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -140,6 +140,12 @@ You set them in your Pelican configuration file.
     If you modify this setting in the Pelican configuration file it will
     completely replace the default extensions!
 
+*   ``PRECOMPRESS_MIN_SIZE`` (int, default is 20)
+
+    Small files tend to end up larger compressed than uncompressed, and any
+    improvement is likely to be marginal. The default setting is chosen to
+    avoid making files that are larger when compressed, but if you have a lot
+    of small files you may want to adjust this.
 
 Testing
 =======

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,1 @@
+from .pelican_precompress import *


### PR DESCRIPTION
* Check to see whether compressed data matches already before recompressing if `PRECOMPRESS_OVERWRITE` is enabled
* Don't compress tiny files - controlled by `PRECOMPRESS_MIN_SIZE`, defaults 20
* Use `multiprocessing.pool` to run multiple compression threads

Multiprocessing code based on https://gitlab.com/bryanbrattlof/pelican-htmlmin