### PR TITLE
WIP: add html minification

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@
 pelican_precompress
 *******************
 
-*Pre-compress your Pelican site using gzip, zopfli, and brotli!*
+*Minify HTML for your Pelican site and pre-compress using gzip, zopfli, and brotli!*
 
 ----
 
@@ -32,17 +32,19 @@ At minimum, you'll need to install the pelican_precompress plugin.
 It will automatically generate gzip files because gzip is built into the
 Python standard library.
 
-However, if you want highly-optimized gzip files you'll need the zopfli module.
-And if you want to have the very best compression currently available, you'll
-need to install the brotli module (which will require extra work in step 3).
+To minify your HTML before compression, the htmlmin module is required.
+If you want highly-optimized gzip files make sure you have the zopfli module.
+For the very best compression currently available, you'll need to install
+the brotli module (which will require extra work in step 3).
 
 ..  code-block:: shell-session
 
     $ pip install pelican_precompress
+    $ pip install htmlmin # This optimizes your HTML, but must be enabled.
     $ pip install zopfli  # This produces smaller gzip'd files. Use it!
     $ pip install brotli  # This requires extra work in step 3.
 
-Further reading: `zopfli`_, `brotli`_
+Further reading: `htmlmin`_, `zopfli`_, `brotli`_
 
 
 2. Configure Pelican
@@ -69,6 +71,13 @@ them alone because the defaults are awesome!
     #     '.css',
     #     '.html',
     #     '.but-the-default-extensions-are-pretty-comprehensive',
+    # }
+    #
+    # HTMLMIN_ENABLED = True or False
+    # HTMLMIN_EXTENSIONS = {'.html', '.htm', }
+    # HTMLMIN_OPTIONS = {
+    #     'remove_comments': True,
+    #     'remove_empty_space': True,
     # }
 
 Further reading: `Pelican plugins`_
@@ -150,6 +159,28 @@ You set them in your Pelican configuration file.
 
     To try compressing every file regardless of size, set this to ``0``.
 
+*   ``HTMLMIN_ENABLED`` (bool, default is False)
+
+    Minifies HTML using htmlmin.
+    You might set this to ``False`` during development.
+    As with ``PRECOMPRESS_ZOPFLI`` and ``PRECOMPRESS_BROTLI``, if the htmlmin
+    module isn't installed then nothing will happen.
+
+*   ``HTMLMIN_EXTENSIONS`` (Set[str], defaults to {'.html', '.htm'})
+
+    This setting controls which file extensions will be minified.
+
+    If you modify this setting in the Pelican configuration file it will
+    completely replace the default extensions!
+
+*   ``HTMLMIN_OPTIONS`` (dict)
+
+    This setting controls the options passed to the ``htmlmin.minify``
+    function. The only deviations from htmlmin's defaults are that
+    ``remove_optional_attribute_quotes`` is ``False`` and ``code`` has been
+    added to ``pre_tags``.
+
+Further reading: `htmlmin API reference`_
 
 Testing
 =======
@@ -178,6 +209,8 @@ Further reading: `tox`_, `venv`_, `pytest`_, `pyfakefs`_, `coverage`_
 
 ..  _Pelican: https://getpelican.com/
 ..  _Pelican plugins: https://docs.getpelican.com/en/latest/plugins.html
+..  _htmlmin: https://htmlmin.readthedocs.io/en/latest/
+..  _htmlmin API reference: https://htmlmin.readthedocs.io/en/latest/reference.html
 ..  _zopfli: https://pypi.org/project/zopfli/
 ..  _brotli: https://pypi.org/project/Brotli/
 ..  _gzip_static: https://nginx.org/en/docs/http/ngx_http_gzip_static_module.html#gzip_static

--- a/pelican_precompress.py
+++ b/pelican_precompress.py
@@ -2,15 +2,18 @@
 # Copyright 2019-2020 Kurt McKee <contactme@kurtmckee.org>
 # Released under the MIT license.
 
+from collections import deque
 import functools
 import gzip
 import logging
 import multiprocessing
+import os
 import pathlib
+import shutil
 from typing import Dict, Iterable, Optional, Set, Union
 import zlib
 
-__version__ = '1.1.1'
+__version__ = '1.2.0'
 
 log = logging.getLogger(__name__)
 
@@ -20,6 +23,13 @@ try:
 except ModuleNotFoundError:
     log.debug('pelican is not installed.')
     pelican = None
+
+# htmlmin support is optional.
+try:
+    import htmlmin
+except ModuleNotFoundError:
+    log.debug('htmlmin is not installed.')
+    htmlmin = None
 
 # brotli support is optional.
 try:
@@ -52,15 +62,23 @@ DEFAULT_TEXT_EXTENSIONS: Set[str] = {
     '.xsl',
 }
 
+DEFAULT_HTML_EXTENSIONS: Set[str] = { '.htm', '.html', }
 
 class FileSizeIncrease(Exception):
     """Indicate that the file size increased after compression."""
     pass
 
 
-def get_paths_to_compress(settings: Dict[str, pathlib.Path]) -> Iterable[pathlib.Path]:
+def copystat(src, dst):
+    shutil.copystat(src, dst)
+    stat = os.stat(src)
+    os.chown(dst, stat.st_uid, stat.st_gid)
+
+
+def get_paths_to_process(settings: Dict[str, pathlib.Path]) -> Iterable[pathlib.Path]:
+    extensions = settings['PRECOMPRESS_TEXT_EXTENSIONS'] | settings['HTMLMIN_EXTENSIONS']
     for path in pathlib.Path(settings['OUTPUT_PATH']).rglob('*'):
-        if path.suffix in settings['PRECOMPRESS_TEXT_EXTENSIONS']:
+        if path.suffix in extensions:
             yield path
 
 
@@ -69,6 +87,7 @@ def get_settings(instance) -> Dict[str, Union[bool, pathlib.Path, Set[str]]]:
 
     settings = {
         'OUTPUT_PATH': pathlib.Path(instance.settings['OUTPUT_PATH']),
+
         'PRECOMPRESS_BROTLI': instance.settings.get('PRECOMPRESS_BROTLI', bool(brotli)),
         'PRECOMPRESS_GZIP': instance.settings.get('PRECOMPRESS_GZIP', True),
         'PRECOMPRESS_ZOPFLI': instance.settings.get('PRECOMPRESS_ZOPFLI', bool(zopfli)),
@@ -77,7 +96,25 @@ def get_settings(instance) -> Dict[str, Union[bool, pathlib.Path, Set[str]]]:
         'PRECOMPRESS_TEXT_EXTENSIONS': set(
             instance.settings.get('PRECOMPRESS_TEXT_EXTENSIONS', DEFAULT_TEXT_EXTENSIONS)
         ),
+
+        'HTMLMIN_ENABLED': instance.settings.get('HTMLMIN_ENABLED', False),
+        'HTMLMIN_EXTENSIONS': set(
+            instance.settings.get('HTMLMIN_EXTENSIONS', DEFAULT_HTML_EXTENSIONS)
+        ),
+        # Merge the second dict (config file entries) over the first (defaults).
+        # https://stackoverflow.com/a/26853961
+        'HTMLMIN_OPTIONS': {**{
+            # enabling this option tends to result
+            # in larger compressed output
+            'remove_optional_attribute_quotes': False,
+            'pre_tags': ['pre', 'code', 'textarea']
+        }, **instance.settings.get('HTMLMIN_OPTIONS', {})},
     }
+
+    # If htmlmin is enabled, it must be installed.
+    if settings['HTMLMIN_ENABLED'] and not htmlmin:
+        log.error('Disabling HTML minification because htmlmin is not installed.')
+        settings['HTMLMIN_ENABLED'] = False
 
     # If brotli is enabled, it must be installed.
     if settings['PRECOMPRESS_BROTLI'] and not brotli:
@@ -93,34 +130,34 @@ def get_settings(instance) -> Dict[str, Union[bool, pathlib.Path, Set[str]]]:
     if settings['PRECOMPRESS_ZOPFLI']:
         settings['PRECOMPRESS_GZIP'] = False
 
+    extensions = settings['PRECOMPRESS_TEXT_EXTENSIONS'] | settings['HTMLMIN_EXTENSIONS']
+
     # '.br' and '.gz' are excluded extensions.
-    excluded_extensions = {
-        extension
-        for extension in {'.br', '.gz'}
-        if extension in settings['PRECOMPRESS_TEXT_EXTENSIONS']
-    }
-    for count, extension in enumerate(excluded_extensions, 1):
-        if count == 1:
-            log.warning('gzip and brotli file extensions are excluded.')
-        log.warning(f'Removing "{extension}" from the set of text file extensions to pre-compress.')
-        settings['PRECOMPRESS_TEXT_EXTENSIONS'].remove(extension)
+    excluded_extensions = extensions & {'.br', '.gz'}
+    if len(excluded_extensions):
+        log.warning('Gzip and Brotli file extensions are excluded.')
 
     # All file extensions must start with a period.
     invalid_extensions = {
         extension
-        for extension in settings['PRECOMPRESS_TEXT_EXTENSIONS']
+        for extension in extensions
         if not extension.startswith('.')
     }
-    for count, extension in enumerate(invalid_extensions, 1):
-        if count == 1:
-            log.warning('File extensions must start with a period.')
-        log.warning(f'Removing "{extension}" from the set of text file extensions to pre-compress.')
-        settings['PRECOMPRESS_TEXT_EXTENSIONS'].remove(extension)
+    if len(invalid_extensions):
+        log.warning('File extensions must start with a period.')
+
+    for extension in excluded_extensions | invalid_extensions:
+        if extension in settings['HTMLMIN_EXTENSIONS']:
+            log.warning(f'Removing "{extension}" from the set of html file extensions to minify.')
+            settings['HTMLMIN_EXTENSIONS'].remove(extension)
+        if extension in settings['PRECOMPRESS_TEXT_EXTENSIONS']:
+            log.warning(f'Removing "{extension}" from the set of text file extensions to pre-compress.')
+            settings['PRECOMPRESS_TEXT_EXTENSIONS'].remove(extension)
 
     return settings
 
 
-def compress_files(instance):
+def process_files(instance):
     settings = get_settings(instance)
 
     # *formats* contains the following information:
@@ -141,25 +178,61 @@ def compress_files(instance):
             ('zopfli', '.gz', compress_with_zopfli, decompress_with_gzip),
         )
 
+    pending = deque()
     pool = multiprocessing.Pool()
-
     minimum_size = settings['PRECOMPRESS_MIN_SIZE']
-    for path in get_paths_to_compress(settings):
-        # Ignore files smaller than the minimum size.
-        if minimum_size and path.stat().st_size < minimum_size:
-            log.info(f'{path} is less than {minimum_size} bytes. Skipping.')
-            return
+    def run_compressors(data, path):
+        if path.suffix in settings['PRECOMPRESS_TEXT_EXTENSIONS']:
+            # Ignore files smaller than the minimum size.
+            if minimum_size and path.stat().st_size < minimum_size:
+                log.info(f'{path} is less than {minimum_size} bytes. Skipping.')
+                return
 
+            # run each enabled compressor
+            for enabled_format in enabled_formats:
+                pool.apply_async(compress_worker, (data, path, enabled_format, settings))
+
+    for path in get_paths_to_process(settings):
         data = path.read_bytes()
 
-        for enabled_format in enabled_formats:
-            pool.apply_async(worker, (data, path, enabled_format, settings))
+        # for files being processed by htmlmin, that needs to finish before
+        # the compressors run - the AsyncResult object is saved to the pending
+        # queue so that we can check for completion before compressing
+        if settings['HTMLMIN_ENABLED'] and path.suffix in settings['HTMLMIN_EXTENSIONS']:
+            pending.append(pool.apply_async(htmlmin_worker, (data, path, settings)))
+        else:
+            run_compressors(data, path)
+
+    while len(pending):
+        for result in list(pending):
+            # 0.001 is one millisecond - this is somewhat arbitrary and may
+            # need to be adjusted. If it's too small, a lot of CPU time will be
+            # spent iterating through the pending results. If it's too large,
+            # a lot of wall time will be spent idly waiting for htmlmin.
+            result.wait(0.001)
+            if result.ready():
+                pending.remove(result)
+                run_compressors(*result.get())
 
     pool.close()
     pool.join()
 
 
-def worker(data, path, enabled_format, settings):
+def htmlmin_worker(data, path, settings):
+    try:
+        with open(path, 'wb') as f:
+            rawhtml = data.decode('utf-8')
+            minhtml = htmlmin.minify(rawhtml, **settings['HTMLMIN_OPTIONS'])
+            data = minhtml.encode('utf-8')
+            f.seek(0)
+            f.write(data)
+            f.truncate()
+            return (data, path)
+    except Exception as e:
+        log.exception(f'Minification of {path} failed!')
+
+
+def compress_worker(data, path, enabled_format, settings):
     name, extension, compressor, decompressor = enabled_format
 
     destination = path.with_name(path.name + extension)
@@ -172,6 +245,7 @@ def worker(data, path, enabled_format, settings):
         # Don't re-compress if the input hasn't changed.
         destination_data = decompressor(destination)
         if data == destination_data:
+            copystat(path, destination)
             log.info(f'{destination} exists with correct data. Skipping.')
             return
 
@@ -186,9 +260,14 @@ def worker(data, path, enabled_format, settings):
     except FileSizeIncrease:
         log.info(f'{name} compression caused "{path}" to become larger. Skipping.')
         return
+    except Exception as e:
+        log.exception(f'Compression of "{path}" with {name} failed!')
+        return
 
     with destination.open('wb') as file:
         file.write(blob)
+
+    copystat(path, destination)
 
 
 def validate_file_sizes(wrapped):
@@ -246,4 +325,4 @@ def compress_with_zopfli(data: bytes) -> bytes:
 
 def register():
     # Wait until all of the files are written.
-    pelican.signals.finalized.connect(compress_files)
+    pelican.signals.finalized.connect(process_files)


### PR DESCRIPTION
Slightly reworked from some changes I'm using locally. Pelican's execution order for plugins that have hooked a given signal is non-deterministic - previously this was seemingly only in theory, but in current versions it's become a problem in practice.

This patch adds optional HTML minification in addition to precompression. It's turned off by default to avoid surprises to existing users of the plugin.

Parallelism is preserved as much as possible. 

TODO: Test coverage - I'm not much good at writing tests. I added a few, but the coverage is still a bit lacking.