### PR TITLE
Use flake8-toml-config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,6 +46,7 @@ repos:
     hooks:
       - id: "flake8"
         additional_dependencies:
+          - "flake8-toml-config==1.0.0"
           - "flake8-bugbear==24.12.12"
 
   - repo: "https://github.com/editorconfig-checker/editorconfig-checker"

--- a/changelog.d/20250806_081304_kurtmckee_flake8_toml_config.rst
+++ b/changelog.d/20250806_081304_kurtmckee_flake8_toml_config.rst
@@ -1,0 +1,5 @@
+Development
+-----------
+
+*   Migrate the flake8 configuration to ``pyproject.toml`` using
+    the `flake8-toml-config <https://github.com/kurtmckee/flake8-toml-config>`_ plugin.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,15 @@ source = [
 fail_under = 100
 
 
+# flake8
+# ------
+
+[tool.flake8]
+max-line-length = 80
+extend-select = ["B950"]
+extend-ignore = ["E203", "E501", "E701"]
+
+
 # isort
 # -----
 

--- a/src/pelican/plugins/precompress/__init__.py
+++ b/src/pelican/plugins/precompress/__init__.py
@@ -109,7 +109,7 @@ def get_settings(instance) -> dict[str, bool | pathlib.Path | set[str]]:
         log.warning("brotli, gzip, and zstandard file extensions are excluded.")
     for extension in excluded_extensions:
         log.warning(
-            f'Removing "{extension}" from the set of text file extensions to pre-compress.'
+            f'Removing "{extension}" from the set of file extensions to pre-compress.'
         )
         settings["PRECOMPRESS_TEXT_EXTENSIONS"].remove(extension)
 
@@ -123,7 +123,7 @@ def get_settings(instance) -> dict[str, bool | pathlib.Path | set[str]]:
         log.warning("File extensions must start with a period.")
     for extension in invalid_extensions:
         log.warning(
-            f'Removing "{extension}" from the set of text file extensions to pre-compress.'
+            f'Removing "{extension}" from the set of file extensions to pre-compress.'
         )
         settings["PRECOMPRESS_TEXT_EXTENSIONS"].remove(extension)
 

--- a/tox.ini
+++ b/tox.ini
@@ -87,10 +87,3 @@ passenv =
 commands =
     poetry version "{env:VERSION}"
     scriv collect
-
-
-[flake8]
-max-line-length = 88
-extend-ignore =
-    E203,
-    E501,


### PR DESCRIPTION

Push the flake8 configuration to `pyproject.toml` using the [flake8-toml-config](https://github.com/kurtmckee/flake8-toml-config) plugin.


<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>